### PR TITLE
PIE-45: implemented counter and button on homepage

### DIFF
--- a/assets/js/patients.js
+++ b/assets/js/patients.js
@@ -33,7 +33,7 @@ $(document).ready(function () {
             $(this).prop('Counter', 0).animate({
                Counter: $(this).text()
             }, {
-               duration: 1000,
+               duration: 2000,
                easing: 'linear',
                step: function (now) {
                   $(this).text(Math.ceil(now));

--- a/assets/js/patients.js
+++ b/assets/js/patients.js
@@ -10,3 +10,37 @@ $('.show-more-button').on('click', function (event) {
 $('.close-icon').on('click', function () {
    $('.collapse.show').collapse('hide');
 });
+
+// counter animation
+var runsOnce = true;
+
+function isScrolledIntoView($elem) {
+   if ($($elem).length) {
+      var windowTop = $(window).scrollTop();
+      var windowBottom = windowTop + $(window).height();
+      var elem = $elem.offset().top + $elem.height()/2;
+      return ((elem <= windowBottom) && (elem >= windowTop));
+   }
+   return false;
+};
+
+$(document).ready(function () {
+   $(document).on('scroll', function () {
+      if (isScrolledIntoView($('.counter')) && runsOnce) {
+         $('.counter').each(function () {
+            const width = $(this).width();
+            $(this).width(width);
+            $(this).prop('Counter', 0).animate({
+               Counter: $(this).text()
+            }, {
+               duration: 1000,
+               easing: 'linear',
+               step: function (now) {
+                  $(this).text(Math.ceil(now));
+               }
+            });
+         });
+         runsOnce = false;
+      }
+   }).trigger('scroll');
+});

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -8,3 +8,30 @@
 add_shortcode( 'get_icon_url', function( $atts ){
   return get_template_directory_uri() . '/assets/icons/' . $atts['image'];
 });
+
+function patients_button( $atts, $content=null ) {
+  $atts = shortcode_atts(
+    array (
+      'title' => '',
+      'link' => '',
+      'align' => 'left'
+    ), $atts
+  );
+  
+  if ($atts['title'] != '' && $atts['link'] != '') {
+    return '<div class="text-'.$atts['align'].'"><a href="'.get_home_url().'/'.$atts['link'].'" class="btn btn-primary" role="button">'.$atts['title'].'</a></div>';
+  }
+}
+add_shortcode( 'button', 'patients_button' );
+
+function patients_counter( $atts, $content=null ) {
+  $atts = shortcode_atts(
+    array (
+      'number' => '',
+      'description' => ''
+    ), $atts
+  );
+  
+  return '<div class="d-flex flex-row align-items-baseline"><h2 class="counter">'.$atts['number'].'</h2><h3 class="pl-2">'.$atts['description'].'</h3></div>';
+}
+add_shortcode( 'counter', 'patients_counter' );


### PR DESCRIPTION
Will need to add these shortcodes on Homepage paragraph section for this to work. Implemented so that button shortcode cannot link to pages outside of the domain. This makes the shortcode easier to read/change.
```
[counter number=999 description=”Students helped”]
[button align=center title=”Contact Us” link=”contact-us”]
```